### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -84,6 +84,8 @@ jobs:
           fi
 
   build:
+    permissions:
+      contents: read
     needs: prepare
     if: ${{ fromJson(needs.prepare.outputs.matrix).include[0] != null }}
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/landaiqing/voidraft/security/code-scanning/2](https://github.com/landaiqing/voidraft/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key for the `build` job (starting at line 86). Set the permissions to the least required for this job. According to GitHub's documentation and the workflow steps, the `build` job primarily needs to fetch source code and upload artifacts—both are supported with `contents: read`. The fix involves inserting:

```yaml
permissions:
  contents: read
```

directly under `build:`, aligning it at the same indentation as `runs-on` in the `build` job specification. This limits the `GITHUB_TOKEN`'s access to read-only for repository contents during the build step. No other code or dependencies are affected or need to be considered.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
