### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,6 +28,7 @@ env:
 jobs:
   # 准备构建配置
   prepare:
+    permissions: {}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
Potential fix for [https://github.com/landaiqing/voidraft/security/code-scanning/1](https://github.com/landaiqing/voidraft/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `prepare` job in the workflow file, specifying the minimum required level (ideally no access if not needed, i.e., `permissions: {}`). This configures the GITHUB_TOKEN issued to the job to have no permissions, thereby adhering to the principle of least privilege. 

The change should be made in `.github/workflows/build-release.yml`, specifically at the top of the `prepare` job definition, directly after (or before) `runs-on: ubuntu-latest`.

No additional imports, methods, or variables are needed—simply introduce the new `permissions: {}` line to the YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
